### PR TITLE
Corrige processamento de arquivo xsd para que possa ser feito a busca…

### DIFF
--- a/src/xsd_parser.py
+++ b/src/xsd_parser.py
@@ -177,7 +177,7 @@ class XsdParser:
 
         # Processar elementos filhos de sequence
         for sequence in complex_type_elem.xpath(
-            ".//xsd:sequence", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
+            "./xsd:sequence", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
         ):
             for child in sequence.xpath(
                 "./xsd:element", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
@@ -186,16 +186,20 @@ class XsdParser:
 
         # Processar elementos filhos de choice
         for choice in complex_type_elem.xpath(
-            ".//xsd:choice", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
+            "./xsd:choice", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
         ):
             choice_elements = []
-            for child in choice.xpath(
-                "./xsd:element", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
+            for sequence in choice.xpath(
+                "./xsd:sequence", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
             ):
-                choice_element = self._create_element_from_node(child)
-                if choice_element:
-                    choice_element.parent = parent_element
-                    choice_elements.append(choice_element)
+                for child in sequence.xpath(
+                    "./xsd:element",
+                    namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"},
+                ):
+                    choice_element = self._create_element_from_node(child)
+                    if choice_element:
+                        choice_element.parent = parent_element
+                        choice_elements.append(choice_element)
 
             if choice_elements:
                 parent_element.choices.append(choice_elements)


### PR DESCRIPTION
… em profundidade em elementos com ComplexType implícito

## O que mudou?

A classe XsdParser agora procura pelos elementos, dentro de complexType, passando de camada em camada, não mais pulando-as e agora sendo específico quanto ao local que cada tag deve existir.

---

## Tarefas Relacionadas

- [ ] #ID1 — Alteração no método _process_complex_type_children da classe XsdParser.
- [ ] #ID2 — (opcional)
- [ ] #ID3 — (opcional)

---

## Mudanças Realizadas

Liste as principais alterações técnicas feitas neste PR, focando em clareza:  
- [ ] Utilização de [serviço/tecnologia] para [finalidade].  
- [ ] Adaptação da codebase para estrutura compatível com [stack/framework].  
- [ ] Implementação de suporte a [feature, ex.: multitenants].  
- [X] Correção de [problemas específicos, ex.: paths, URLs].  
- [ ] Otimização de [componente], explicando o motivo.

---

## Evidências

Mapper gerado com tag Rps somente dentro de ListaRps (Antes a tag se duplicava, ficando dentro de ListaRps e dentro de LoteRps)
![image](https://github.com/user-attachments/assets/87871e85-50e0-4d8f-a91f-154fa61c7cb7)

---

## Checklist

- [X] Código revisado e testado localmente.
- [ ] Documentação atualizada, se aplicável.
- [ ] Testes automatizados atualizados/criados, se necessário.

---

## Comentários adicionais

Adicione qualquer contexto, limitação ou informação relevante para quem vai revisar o PR.
