### PR TITLE
adiciona estrutura que mapeia choice / element

### DIFF
--- a/src/xsd_parser.py
+++ b/src/xsd_parser.py
@@ -184,6 +184,21 @@ class XsdParser:
             ):
                 self._process_child_element(child, parent_element)
 
+        for choice in complex_type_elem.xpath(
+            "./xsd:choice", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
+        ):
+            choice_elements = []
+            for child in choice.xpath(
+                "./xsd:element", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}
+            ):
+                choice_element = self._create_element_from_node(child)
+                if choice_element:
+                    choice_element.parent = parent_element
+                    choice_elements.append(choice_element)
+
+            if choice_elements:
+                parent_element.choices.append(choice_elements)
+
         # Processar elementos filhos de choice
         for choice in complex_type_elem.xpath(
             "./xsd:choice", namespaces={"xsd": "http://www.w3.org/2001/XMLSchema"}


### PR DESCRIPTION
## O que mudou?

Agora ao se deparar com um caminho como choice -> element, o mapeamento é feito corretamente.

---

## Mudanças Realizadas

Liste as principais alterações técnicas feitas neste PR, focando em clareza:  
- Criação de estrutura no código que mapeia esse tipo de caminho.

---

## Evidências

[Gravação de tela de 2025-06-12 09-15-29.webm](https://github.com/user-attachments/assets/276211a3-e679-479b-8492-5bcc79b14836)

---

## Checklist

- [X] Código revisado e testado localmente.
- [ ] Documentação atualizada, se aplicável.
- [ ] Testes automatizados atualizados/criados, se necessário.

---
